### PR TITLE
🧹 Remove unused 'time' import in fuzzymatch.py

### DIFF
--- a/pkgs/fuzzymatch.py
+++ b/pkgs/fuzzymatch.py
@@ -1,4 +1,4 @@
-import os, time, random, ppdeep, shutil
+import os, random, ppdeep, shutil
 from tqdm import tqdm
 
 from pkgs.utils import listdir


### PR DESCRIPTION
🎯 **What:** Removed the unused `time` import from `pkgs/fuzzymatch.py`.
💡 **Why:** This improves the maintainability and readability of the codebase by eliminating dead code.
✅ **Verification:** Ran the full pytest suite (`python -m pytest tests`) to ensure no functionality was broken. All tests passed.
✨ **Result:** A slightly cleaner file with no regressions.

---
*PR created automatically by Jules for task [1326939449417537562](https://jules.google.com/task/1326939449417537562) started by @himadriganguly*