### PR TITLE
🧹 [code health] Remove unused tqdm import from stringdump

### DIFF
--- a/pkgs/stringdump.py
+++ b/pkgs/stringdump.py
@@ -1,6 +1,5 @@
 import re, sys, os
 from clint.textui import puts, colored
-from tqdm import tqdm
 
 from pkgs.utils import md5sum
 from pkgs.utils import splitDirFileName


### PR DESCRIPTION
🎯 **What:** Removed unused `tqdm` import from `pkgs/stringdump.py`.
💡 **Why:** Dead code elimination. Removes an unnecessary external dependency import, which improves readability and code health.
✅ **Verification:** Verified with grep that `tqdm` is not used in the file. Re-ran the test suite with `python -m pytest tests` and all tests passed.
✨ **Result:** Improved maintainability by reducing dead code and unnecessary imports.

---
*PR created automatically by Jules for task [3381583622613035539](https://jules.google.com/task/3381583622613035539) started by @himadriganguly*