### PR TITLE
🧹 Remove unused time import from findfiles.py

### DIFF
--- a/pkgs/findfiles.py
+++ b/pkgs/findfiles.py
@@ -1,4 +1,4 @@
-import os, time
+import os
 from tqdm import tqdm
 
 from pkgs.utils import listdir


### PR DESCRIPTION
🎯 **What:** Removed unused `time` import from `pkgs/findfiles.py`.
💡 **Why:** Having unused imports clutters the file and can make it slightly harder to maintain. Removing unused imports improves code health and cleanliness.
✅ **Verification:** I ran `python -m pytest tests` and ensured all tests passed successfully.
✨ **Result:** The codebase is slightly cleaner and has fewer unused dependencies per module.

---
*PR created automatically by Jules for task [6328442563342759491](https://jules.google.com/task/6328442563342759491) started by @himadriganguly*