### PR TITLE
🔒 Replace weak MD5 hash with SHA-256

### DIFF
--- a/pkgs/stringdump.py
+++ b/pkgs/stringdump.py
@@ -2,7 +2,7 @@ import re, sys, os
 from clint.textui import puts, colored
 from tqdm import tqdm
 
-from pkgs.utils import md5sum
+from pkgs.utils import sha256sum
 from pkgs.utils import splitDirFileName
 
 class StringDump:
@@ -43,7 +43,7 @@ class StringDump:
         if len(allStrings) > 0:
             return allStrings
         else:
-          puts(colored.red('[!] No Extractable Attributes Present in\nFile: {}\nHash: {}\nPlease Remove it from the Sample Set and Try Again!'.format(filePath,md5sum(filePath))))
+          puts(colored.red('[!] No Extractable Attributes Present in\nFile: {}\nHash: {}\nPlease Remove it from the Sample Set and Try Again!'.format(filePath,sha256sum(filePath))))
           sys.exit(1)
 
     def __removeBlackListStrings(self, allStrings):

--- a/pkgs/utils.py
+++ b/pkgs/utils.py
@@ -3,9 +3,9 @@ import os, hashlib
 def splitDirFileName(filePath):
     return os.path.split(os.path.abspath(filePath))
 
-def md5sum(filename):
+def sha256sum(filename):
   fh = open(filename, 'rb')
-  m = hashlib.md5()
+  m = hashlib.sha256()
   while True:
       data = fh.read(2048)
       if not data:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,7 @@
 import pytest
 import os
 import tempfile
-from pkgs.utils import splitDirFileName, md5sum, listdir
+from pkgs.utils import splitDirFileName, sha256sum, listdir
 
 def test_splitDirFileName():
     path = "/path/to/my/file.txt"
@@ -9,13 +9,13 @@ def test_splitDirFileName():
     assert dir_name == "/path/to/my"
     assert file_name == "file.txt"
 
-def test_md5sum():
+def test_sha256sum():
     with tempfile.NamedTemporaryFile(delete=False) as f:
         f.write(b"hello world")
         temp_path = f.name
 
-    # md5 of "hello world" is 5eb63bbbe01eeed093cb22bb8f5acdc3
-    assert md5sum(temp_path) == "5eb63bbbe01eeed093cb22bb8f5acdc3"
+    # sha256 of "hello world" is b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9
+    assert sha256sum(temp_path) == "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9"
     os.remove(temp_path)
 
 def test_listdir():

--- a/yarasilly2.py
+++ b/yarasilly2.py
@@ -5,7 +5,7 @@ from tqdm import tqdm
 from datetime import datetime
 from jinja2 import Environment, FileSystemLoader
 
-from pkgs.utils import md5sum, listdir
+from pkgs.utils import sha256sum, listdir
 
 # sys.path.append('./libs')
 
@@ -91,7 +91,7 @@ def main(rulename=None, filetype=None, matchpatternfile=None, inputfilepath=None
 
         stringDumpObj = StringDump(dirPath, 'office', tempFolder, blocksize)
         for file in findFilesObj.searchFiles():
-            fileHash.append(md5sum(file))
+            fileHash.append(sha256sum(file))
             stringDumpObj.dumpStringsToTempFile(file)
 
         del findFilesObj


### PR DESCRIPTION
🎯 **What:** Replaced the use of the weak `hashlib.md5()` cryptographic hash function with `hashlib.sha256()` across the codebase.
⚠️ **Risk:** MD5 is computationally weak and vulnerable to collision attacks, making it insecure for hashing where collision resistance is required.
🛡️ **Solution:** Updated `md5sum` function in `pkgs/utils.py` to `sha256sum` using `hashlib.sha256()`. Updated all usages in `yarasilly2.py` and `pkgs/stringdump.py`. Updated the corresponding unit tests to verify the SHA-256 hash.

---
*PR created automatically by Jules for task [5412172090202845126](https://jules.google.com/task/5412172090202845126) started by @himadriganguly*