### PR TITLE
🧪 [test] Improve string blacklist filtering testing

### DIFF
--- a/tests/test_stringdump.py
+++ b/tests/test_stringdump.py
@@ -1,6 +1,7 @@
 import pytest
 import os
 import tempfile
+from unittest.mock import patch, mock_open
 from pkgs.stringdump import StringDump
 
 def test_stringdump_getstrings():
@@ -17,3 +18,34 @@ def test_stringdump_getstrings():
 
         # Test url extraction
         assert any("http://example.com" in s for s in strings if isinstance(s, str))
+
+@patch('builtins.open')
+def test_remove_blacklist_strings(mock_open_func):
+    sd = StringDump('/fake_dir', 'office', '/fake_temp', blocksize=1024)
+
+    def mock_open_side_effect(filename, *args, **kwargs):
+        if filename.endswith('_blacklist'):
+            return mock_open(read_data="blacklisted_word\nanother_blacklisted\n").return_value
+        elif filename.endswith('_regexblacklist'):
+            return mock_open(read_data="^regex_match_.*\n.*_regex_end$\n").return_value
+        else:
+            return mock_open(read_data="").return_value
+
+    mock_open_func.side_effect = mock_open_side_effect
+
+    input_strings = [
+        ['  hello  ', 'world'],
+        ['blacklisted_word', 'keep_me'],
+        ['regex_match_123', 'normal_regex_end'],
+        ['valid_string']
+    ]
+
+    result = sd._StringDump__removeBlackListStrings(input_strings)
+
+    assert 'hello' in result
+    assert 'world' in result
+    assert 'keep_me' in result
+    assert 'valid_string' in result
+    assert 'blacklisted_word' not in result
+    assert 'regex_match_123' not in result
+    assert 'normal_regex_end' not in result


### PR DESCRIPTION
🎯 **What:** The testing gap addressed is the lack of unit tests for the string blacklist filtering function `__removeBlackListStrings` in `StringDump`. This is addressed by using `unittest.mock.patch` to mock `builtins.open` so that we can test the filtering behavior cleanly without interacting with the disk.
📊 **Coverage:** The new test suite comprehensively covers four scenarios: 1) removal of static blacklist terms, 2) removal of regex blacklist matches, 3) retention of valid strings, and 4) proper whitespace stripping logic prior to comparison.
✨ **Result:** Test coverage for the `pkgs/stringdump.py` module is improved, allowing developers to refactor with confidence knowing that blacklist and regex-based filtering functionality is thoroughly validated using precise mocks.

---
*PR created automatically by Jules for task [4509440624278725407](https://jules.google.com/task/4509440624278725407) started by @himadriganguly*