### PR TITLE
🔒 Fix path traversal vulnerability in yara rule name input

### DIFF
--- a/yarasilly2.py
+++ b/yarasilly2.py
@@ -33,7 +33,7 @@ def main(rulename=None, filetype=None, matchpatternfile=None, inputfilepath=None
     logLevelDict = {'CRITICAL': logging.CRITICAL, 'ERROR': logging.ERROR, 'WARNING': logging.WARNING, 'INFO': logging.INFO, 'DEBUG': logging.DEBUG}
     foundPattern = 0
 
-    pattern = re.compile(r"^[A-Za-z]\S*\w*$")
+    pattern = re.compile(r"^[A-Za-z]\w*$")
     if not pattern.match(rulename):
         puts(colored.red(("[!] Wrong pattern for rule name.\n")))
         sys.exit(1)


### PR DESCRIPTION
🎯 **What:** The application was vulnerable to path traversal through the `rulename` argument, because its regular expression validation incorrectly permitted any non-whitespace character, including path separators (`/`) and dot traversal components (`.`).
⚠️ **Risk:** The vulnerability could allow an attacker to write generated YARA rules to arbitrary filesystem locations if exploited.
🛡️ **Solution:** The regular expression checking `rulename` was updated to `^[A-Za-z]\w*$`, so that it strictly expects a leading alphabet character followed only by alphanumeric characters and underscores.

---
*PR created automatically by Jules for task [3568755601816459877](https://jules.google.com/task/3568755601816459877) started by @himadriganguly*