### PR TITLE
🔒 Fix template injection vulnerability in rule generation

### DIFF
--- a/yarasilly2.py
+++ b/yarasilly2.py
@@ -15,6 +15,12 @@ from pkgs.findfiles import FindFiles
 from pkgs.searchpattern import SearchPattern
 from pkgs.stringdump import StringDump
 
+def sanitize_input(val):
+    if not isinstance(val, str):
+        return val
+    return val.replace('\\', '\\\\').replace('"', '\\"').replace('\n', '').replace('\r', '')
+
+
 @click.command(context_settings=dict(show_default=True))
 @click.option('--rulename', '-r', type=click.STRING, help='Provide a rule name with no spaces and must start with letter.', required=True)
 @click.option('--filetype', '-f', type=click.Choice(['office'], case_sensitive=False), help='Select sample set file type choices.', required=True)
@@ -112,11 +118,11 @@ def main(rulename=None, filetype=None, matchpatternfile=None, inputfilepath=None
 
         if(foundPattern):
             templateValDict = {
-                "ruleName": rulename,
-                "ruleTag": tags,
-                "authorName": author,
+                "ruleName": sanitize_input(rulename),
+                "ruleTag": sanitize_input(tags),
+                "authorName": sanitize_input(author),
                 "date": datetime.now().strftime("%Y-%m-%d"),
-                "desc": description,
+                "desc": sanitize_input(description),
                 "hashArray": fileHash,
                 "fileType": "office"
             }


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
Fixed a template injection vulnerability in `yarasilly2.py` where user-supplied command-line arguments (`rulename`, `tags`, `authorName`, and `desc`) were passed directly to the Jinja2 template (`yaraTemplate.render()`) without any sanitization.

⚠️ **Risk:** The potential impact if left unfixed
An attacker could provide maliciously crafted inputs containing unescaped double quotes or newlines, enabling them to break out of the YARA rule format string constraints and inject arbitrary rule content or malicious metadata blocks. This could lead to generated YARA rules breaking downstream rule engines or injecting deceptive rule conditions.

🛡️ **Solution:** How the fix addresses the vulnerability
Created a `sanitize_input` function that enforces string escaping for backslashes and double quotes, and removes newline characters. Applied this sanitization to the vulnerable dictionary values passed to the template rendering function. Standard Jinja2 `autoescape` was not used because it escapes inputs into HTML entities, which are invalid in a YARA context.

---
*PR created automatically by Jules for task [6128480011088244098](https://jules.google.com/task/6128480011088244098) started by @himadriganguly*