### PR TITLE
🧹 [remove unused time import in findfiles]

### DIFF
--- a/pkgs/findfiles.py
+++ b/pkgs/findfiles.py
@@ -1,4 +1,4 @@
-import os, time
+import os
 from tqdm import tqdm
 
 from pkgs.utils import listdir


### PR DESCRIPTION
* 🎯 **What:** Removed unused `time` import from `pkgs/findfiles.py`.
* 💡 **Why:** Removing unused imports reduces namespace clutter and improves code maintainability.
* ✅ **Verification:** The test suite was run (`python -m pytest tests/`) and continues to pass, ensuring that functionality is unbroken.
* ✨ **Result:** A cleaner codebase with no change in functionality.

---
*PR created automatically by Jules for task [10828064155444630000](https://jules.google.com/task/10828064155444630000) started by @himadriganguly*