### PR TITLE
🧹 Remove unused tqdm import

### DIFF
--- a/yarasilly2.py
+++ b/yarasilly2.py
@@ -1,7 +1,6 @@
 import os, sys, logging, configparser, tempfile, shutil, click, re
 from pyfiglet import Figlet
 from clint.textui import puts, colored
-from tqdm import tqdm
 from datetime import datetime
 from jinja2 import Environment, FileSystemLoader
 


### PR DESCRIPTION
🎯 **What:** Removed unused `tqdm` import from `yarasilly2.py`.
💡 **Why:** To improve code maintainability and remove dead code.
✅ **Verification:** Verified by searching codebase for `tqdm` usages and running the full `pytest` test suite, which all passed successfully.
✨ **Result:** A cleaner global namespace in `yarasilly2.py` without modifying the application's actual behavior.

---
*PR created automatically by Jules for task [5351956010257089695](https://jules.google.com/task/5351956010257089695) started by @himadriganguly*