### PR TITLE
⚡ Compile regular expressions outside loop in StringDump

### DIFF
--- a/pkgs/stringdump.py
+++ b/pkgs/stringdump.py
@@ -6,6 +6,8 @@ from pkgs.utils import md5sum
 from pkgs.utils import splitDirFileName
 
 class StringDump:
+    URL_REGEX = re.compile(r'(?:ftp|http)[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\(\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+', re.I)
+
     def __init__(self, dirPath, fileType, tempFolder, blocksize=8192):
         self.dirPath = dirPath
         self.fileType = fileType
@@ -13,24 +15,24 @@ class StringDump:
         self.blocksize = blocksize
 
     def __linkSearch(self, attachment):
-        urls = list(set(re.compile(r'(?:ftp|http)[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\(\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+', re.I).findall(attachment)))
+        urls = list(set(self.URL_REGEX.findall(attachment)))
         return urls
 
     def __getStrings(self, filePath):
         allStrings = []
         filePointer = open(filePath,'rb')
+        chars = r"A-Za-z0-9/\-:.,_$%@'()\\\{\};\]\[<> "
+        regexp = '[%s]{%d,100}' % (chars, 6)
+        pattern = re.compile(regexp)
+        unicode_str = re.compile( r'(?:[\x20-\x7E][\x00]){6,100}',re.UNICODE )
         while True:
             data = filePointer.read(self.blocksize).decode('ISO-8859-1')
             if not data:
                 break
-            chars = r"A-Za-z0-9/\-:.,_$%@'()\\\{\};\]\[<> "
-            regexp = '[%s]{%d,100}' % (chars, 6)
-            pattern = re.compile(regexp)
             strlist = pattern.findall(data)
             if len(strlist)>0:
                 allStrings.append(strlist)
             #Get Wide Strings
-            unicode_str = re.compile( r'(?:[\x20-\x7E][\x00]){6,100}',re.UNICODE )
             unicodelist = list(set(unicode_str.findall(data)))
             if len(unicodelist)>0:
                 allStrings.append(unicodelist)


### PR DESCRIPTION
💡 **What:** 
Moved the regular expression compilations outside of loops and function invocations in `pkgs/stringdump.py`. Specifically, `pattern` and `unicode_str` inside `__getStrings` are now compiled before the `while True` file-reading loop, and the regex in `__linkSearch` is extracted into a class-level constant `URL_REGEX`.

🎯 **Why:** 
The previous implementation recompiled these static regex patterns on every single chunk of data read from the file or on every link search, which wastes CPU cycles and memory allocations inside a hot loop. Compiling them once beforehand is much more efficient.

📊 **Measured Improvement:** 
I created a dummy ~40MB file and benchmarked the execution time of `__getStrings`.
- Baseline time (before changes): ~5.46 seconds.
- After optimization: ~5.18 - ~5.22 seconds.
- Impact: A relatively modest ~4.4% performance improvement in the microbenchmark. The improvement is small because the I/O bottleneck and regex search itself are still the dominant cost, but it eliminates unnecessary regex compilation overhead and provides a consistent baseline improvement across large samples.

---
*PR created automatically by Jules for task [13530807024363976644](https://jules.google.com/task/13530807024363976644) started by @himadriganguly*