### PR TITLE
🧹 [code health improvement] Remove unreachable OSError exception block

### DIFF
--- a/yarasilly2.py
+++ b/yarasilly2.py
@@ -154,10 +154,6 @@ def main(rulename=None, filetype=None, matchpatternfile=None, inputfilepath=None
         puts(colored.red("[!] Error executing application.\n"))
         logging.exception(error)
         sys.exit(1)
-    except OSError as error:
-        puts(colored.red("[!] Error executing application.\n"))
-        logging.exception(error)
-        sys.exit(1)
     except KeyboardInterrupt:
         puts(colored.red("[!] Application Interrupted.\n"))
         sys.exit(1)


### PR DESCRIPTION
🎯 **What:** Removed the unreachable `except OSError as error:` block in `yarasilly2.py`
💡 **Why:** `OSError` inherits from `Exception` in Python. Since there was already an `except Exception as error:` block immediately preceding the `except OSError` block, the latter was dead code and impossible to reach. Removing this duplication improves the clarity and maintainability of the codebase.
✅ **Verification:** Ran formatting, lint checks, and the full test suite (`python -m pytest tests`) to ensure no breakages or regressions occurred.
✨ **Result:** Cleaned up code and eliminated unreachable dead logic without affecting application behavior.

---
*PR created automatically by Jules for task [14825741433395989362](https://jules.google.com/task/14825741433395989362) started by @himadriganguly*