### PR TITLE
🧹 [Code Health] Remove unreachable sys.exit(1) in pkgs/

### DIFF
--- a/pkgs/findfiles.py
+++ b/pkgs/findfiles.py
@@ -39,4 +39,3 @@ class FindFiles:
 
         except Exception as error:
             raise Exception(error)
-            sys.exit(1)

--- a/pkgs/fuzzymatch.py
+++ b/pkgs/fuzzymatch.py
@@ -71,4 +71,3 @@ class FuzzyMatch:
             print("\n")
         except Exception as error:
             raise Exception(error)
-            sys.exit(1)

--- a/pkgs/searchpattern.py
+++ b/pkgs/searchpattern.py
@@ -68,4 +68,3 @@ class SearchPattern:
             return(self.foundPattern)
         except Exception as error:
             raise Exception(error)
-            sys.exit(1)

--- a/pkgs/stringdump.py
+++ b/pkgs/stringdump.py
@@ -87,4 +87,3 @@ class StringDump:
 
         except Exception as error:
             raise Exception(error)
-            sys.exit(1)


### PR DESCRIPTION
🎯 **What:** Removed unreachable `sys.exit(1)` statements that occurred immediately after `raise Exception(error)` in `pkgs/stringdump.py`, `pkgs/fuzzymatch.py`, `pkgs/searchpattern.py`, and `pkgs/findfiles.py`.
💡 **Why:** `sys.exit(1)` is unreachable immediately following a `raise` statement. Removing these dead statements cleans up technical debt and improves overall codebase maintainability without altering functionality.
✅ **Verification:** Verified the fix by successfully running the full test suite (`python -m pytest tests`) after installing missing dependencies. All 9 tests passed, confirming no regressions. Code review also verified the change is completely safe.
✨ **Result:** Cleaned up unreachable code patterns across 4 core modules, resulting in cleaner and more maintainable code.

---
*PR created automatically by Jules for task [2845237529649790110](https://jules.google.com/task/2845237529649790110) started by @himadriganguly*