### PR TITLE
🧹 Remove unreachable sys.exit(1) calls

### DIFF
--- a/pkgs/findfiles.py
+++ b/pkgs/findfiles.py
@@ -39,4 +39,3 @@ class FindFiles:
 
         except Exception as error:
             raise Exception(error)
-            sys.exit(1)

--- a/pkgs/fuzzymatch.py
+++ b/pkgs/fuzzymatch.py
@@ -71,4 +71,3 @@ class FuzzyMatch:
             print("\n")
         except Exception as error:
             raise Exception(error)
-            sys.exit(1)

--- a/pkgs/searchpattern.py
+++ b/pkgs/searchpattern.py
@@ -68,4 +68,3 @@ class SearchPattern:
             return(self.foundPattern)
         except Exception as error:
             raise Exception(error)
-            sys.exit(1)

--- a/pkgs/stringdump.py
+++ b/pkgs/stringdump.py
@@ -87,4 +87,3 @@ class StringDump:
 
         except Exception as error:
             raise Exception(error)
-            sys.exit(1)


### PR DESCRIPTION
🎯 **What:** Removed unreachable `sys.exit(1)` calls that immediately followed `raise Exception(...)` statements in `pkgs/findfiles.py`, `pkgs/fuzzymatch.py`, `pkgs/searchpattern.py`, and `pkgs/stringdump.py`.

💡 **Why:** This improves maintainability and readability by eliminating dead code. Code that can never be executed adds unnecessary noise and can confuse developers reading the error handling paths.

✅ **Verification:** Verified by ensuring the removed code was strictly unreachable (occurring immediately after an unconditional `raise Exception()`) and by successfully running the full `pytest` test suite (`python -m pytest tests/`), ensuring no existing functionality was broken.

✨ **Result:** A cleaner, more maintainable codebase with consistent error handling patterns and no unreachable exit statements.

---
*PR created automatically by Jules for task [14757060369777998002](https://jules.google.com/task/14757060369777998002) started by @himadriganguly*