### PR TITLE
🧹 [Code health improvement] Remove unreachable sys.exit(1)

### DIFF
--- a/pkgs/findfiles.py
+++ b/pkgs/findfiles.py
@@ -39,4 +39,3 @@ class FindFiles:
 
         except Exception as error:
             raise Exception(error)
-            sys.exit(1)

--- a/pkgs/fuzzymatch.py
+++ b/pkgs/fuzzymatch.py
@@ -71,4 +71,3 @@ class FuzzyMatch:
             print("\n")
         except Exception as error:
             raise Exception(error)
-            sys.exit(1)

--- a/pkgs/searchpattern.py
+++ b/pkgs/searchpattern.py
@@ -68,4 +68,3 @@ class SearchPattern:
             return(self.foundPattern)
         except Exception as error:
             raise Exception(error)
-            sys.exit(1)

--- a/pkgs/stringdump.py
+++ b/pkgs/stringdump.py
@@ -87,4 +87,3 @@ class StringDump:
 
         except Exception as error:
             raise Exception(error)
-            sys.exit(1)


### PR DESCRIPTION
🎯 **What:** Removed unreachable `sys.exit(1)` statements that follow `raise Exception(error)` in `pkgs/findfiles.py`, `pkgs/fuzzymatch.py`, `pkgs/searchpattern.py`, and `pkgs/stringdump.py`.

💡 **Why:** This code is entirely dead and unreachable since the preceding `raise` statement guarantees execution control will leave the block. Removing it cleans up the codebase and reduces cognitive load, improving maintainability.

✅ **Verification:** Ran the full pytest suite (`python -m pytest tests/ -v`) successfully to confirm no regressions were introduced. Note that the reachable `sys.exit(1)` on line 47 of `pkgs/stringdump.py` was correctly preserved.

✨ **Result:** Cleaned up dead code across 4 files, enhancing codebase readability without altering functionality.

---
*PR created automatically by Jules for task [13392407253088580502](https://jules.google.com/task/13392407253088580502) started by @himadriganguly*