### PR TITLE
🔒 Fix path traversal vulnerability in rule name validation

### DIFF
--- a/tests/test_yarasilly2.py
+++ b/tests/test_yarasilly2.py
@@ -1,0 +1,57 @@
+import pytest
+from click.testing import CliRunner
+import yarasilly2
+
+def test_rulename_validation_valid(mocker):
+    # Mock puts and sys.exit to avoid exiting during normal flow if there are other errors
+    mock_puts = mocker.patch('yarasilly2.puts')
+    mock_exit = mocker.patch('sys.exit')
+
+    # We patch FileSystemLoader and Environment so the rest of the script doesn't fail
+    mocker.patch('yarasilly2.FileSystemLoader')
+    mocker.patch('yarasilly2.Environment')
+    mocker.patch('yarasilly2.configparser.ConfigParser')
+
+    runner = CliRunner()
+    runner.invoke(yarasilly2.main, ['-r', 'ValidRuleName_123', '-f', 'office'])
+
+    # puts should not be called with the error message
+    for call in mock_puts.call_args_list:
+        assert 'Wrong pattern for rule name.' not in str(call)
+
+def test_rulename_validation_invalid_path_traversal(mocker):
+    mock_puts = mocker.patch('yarasilly2.puts')
+    mock_exit = mocker.patch('sys.exit')
+
+    runner = CliRunner()
+    runner.invoke(yarasilly2.main, ['-r', '../invalid/rule', '-f', 'office'])
+
+    # puts should be called with the error message
+    called_with_error = False
+    for call in mock_puts.call_args_list:
+        if 'Wrong pattern for rule name.' in str(call):
+            called_with_error = True
+            break
+
+    assert called_with_error, "Expected puts to be called with 'Wrong pattern for rule name.'"
+
+    # Check if mock_exit was called with 1 at least once
+    assert mocker.call(1) in mock_exit.call_args_list, "Expected sys.exit(1) to be called"
+
+def test_rulename_validation_invalid_characters(mocker):
+    mock_puts = mocker.patch('yarasilly2.puts')
+    mock_exit = mocker.patch('sys.exit')
+
+    runner = CliRunner()
+    runner.invoke(yarasilly2.main, ['-r', 'rule@name!', '-f', 'office'])
+
+    called_with_error = False
+    for call in mock_puts.call_args_list:
+        if 'Wrong pattern for rule name.' in str(call):
+            called_with_error = True
+            break
+
+    assert called_with_error, "Expected puts to be called with 'Wrong pattern for rule name.'"
+
+    # Check if mock_exit was called with 1 at least once
+    assert mocker.call(1) in mock_exit.call_args_list, "Expected sys.exit(1) to be called"

--- a/yarasilly2.py
+++ b/yarasilly2.py
@@ -33,7 +33,7 @@ def main(rulename=None, filetype=None, matchpatternfile=None, inputfilepath=None
     logLevelDict = {'CRITICAL': logging.CRITICAL, 'ERROR': logging.ERROR, 'WARNING': logging.WARNING, 'INFO': logging.INFO, 'DEBUG': logging.DEBUG}
     foundPattern = 0
 
-    pattern = re.compile(r"^[A-Za-z]\S*\w*$")
+    pattern = re.compile(r"^[A-Za-z][a-zA-Z0-9_]*$")
     if not pattern.match(rulename):
         puts(colored.red(("[!] Wrong pattern for rule name.\n")))
         sys.exit(1)


### PR DESCRIPTION
🎯 **What:** The previous regex validation `^[A-Za-z]\S*\w*$` for the `rulename` parameter only verified that it started with a letter, but incorrectly permitted symbols like slashes (`/`) and dots (`.`). This allowed path traversal sequences to be passed into the `rulename`, causing the subsequent Yara rule generation logic to write out YARA files to unexpected arbitrary file system paths (e.g., `../invalid/rule.yar`). The regex has been updated to `^[A-Za-z][a-zA-Z0-9_]*$`.

⚠️ **Risk:** A user interacting with the CLI application via automated orchestration (or if integrated with other scripts) could supply a maliciously crafted path for `rulename`. This path traversal could result in overwriting crucial system files or writing files in unintended locations if the CLI runner executes with sufficient privileges.

🛡️ **Solution:** The `pattern` in `yarasilly2.py` line 36 is restricted to only allow alphabetic characters at the start followed exclusively by alphanumeric characters and underscores. I have added `tests/test_yarasilly2.py` which mocks standard output and asserts behavior for valid usage, invalid characters, and a standard path traversal sequence.

---
*PR created automatically by Jules for task [16428051188737758036](https://jules.google.com/task/16428051188737758036) started by @himadriganguly*