### PR TITLE
🧹 [code health] Remove unreachable sys.exit(1) calls after raise Exception

### DIFF
--- a/pkgs/findfiles.py
+++ b/pkgs/findfiles.py
@@ -39,4 +39,3 @@ class FindFiles:
 
         except Exception as error:
             raise Exception(error)
-            sys.exit(1)

--- a/pkgs/fuzzymatch.py
+++ b/pkgs/fuzzymatch.py
@@ -71,4 +71,3 @@ class FuzzyMatch:
             print("\n")
         except Exception as error:
             raise Exception(error)
-            sys.exit(1)

--- a/pkgs/searchpattern.py
+++ b/pkgs/searchpattern.py
@@ -68,4 +68,3 @@ class SearchPattern:
             return(self.foundPattern)
         except Exception as error:
             raise Exception(error)
-            sys.exit(1)

--- a/pkgs/stringdump.py
+++ b/pkgs/stringdump.py
@@ -87,4 +87,3 @@ class StringDump:
 
         except Exception as error:
             raise Exception(error)
-            sys.exit(1)


### PR DESCRIPTION
🎯 **What:** Removed unreachable `sys.exit(1)` statements in `pkgs/stringdump.py`, `pkgs/findfiles.py`, `pkgs/fuzzymatch.py`, and `pkgs/searchpattern.py`. These statements were occurring immediately after a `raise Exception(error)` block and could never be executed.

💡 **Why:** Removing dead code improves code readability, prevents developer confusion about expected control flow, and adheres to clean code practices.

✅ **Verification:** Validated that only the strictly unreachable instances of `sys.exit(1)` were removed (e.g., leaving a valid `sys.exit(1)` that occurs after a standard `puts` call in `stringdump.py`). Ran the full `pytest` test suite, which passed successfully without any regressions.

✨ **Result:** Cleaned up four instances of dead code, improving the overall codebase health and maintainability without altering any functionality.

---
*PR created automatically by Jules for task [900926067059666118](https://jules.google.com/task/900926067059666118) started by @himadriganguly*