### PR TITLE
🧪 [testing improvement] Add missing error test for empty probable virus folder in FuzzyMatch

### DIFF
--- a/tests/test_fuzzymatch.py
+++ b/tests/test_fuzzymatch.py
@@ -12,3 +12,17 @@ def test_fuzzymatch_empty_confirm():
         fm = FuzzyMatch(confirmPath, 80, probablePath, 60, inputFilesPath)
         with pytest.raises(Exception, match="Empty confirm virus sample folder."):
             fm.searchFiles()
+
+
+def test_fuzzymatch_empty_probable():
+    with tempfile.TemporaryDirectory() as confirmPath, \
+         tempfile.TemporaryDirectory() as probablePath, \
+         tempfile.TemporaryDirectory() as inputFilesPath:
+
+        # Create a file in confirmPath so it's not empty
+        with open(os.path.join(confirmPath, "test_file.txt"), "w") as f:
+            f.write("test content")
+
+        fm = FuzzyMatch(confirmPath, 80, probablePath, 60, inputFilesPath)
+        with pytest.raises(Exception, match="Empty probable virus sample folder."):
+            fm.searchFiles()


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
This PR adds a missing unit test to `tests/test_fuzzymatch.py` that verifies `FuzzyMatch.searchFiles()` correctly raises an Exception with the message "Empty probable virus sample folder." when the `probable` folder is empty.

📊 **Coverage:** What scenarios are now tested
The scenario where a non-empty `confirm` folder allows processing to continue but an empty `probable` folder causes a subsequent failure is now explicitly tested.

✨ **Result:** The improvement in test coverage
The error handling logic in `pkgs/fuzzymatch.py` around the `probablePath` validation is now fully verified by the test suite, increasing the robustness and code coverage of the `FuzzyMatch` module.

---
*PR created automatically by Jules for task [11386473877837727249](https://jules.google.com/task/11386473877837727249) started by @himadriganguly*