### PR TITLE
🧹 [code health improvement] Remove unnecessary exception wrapping in stringdump.py

### DIFF
--- a/pkgs/stringdump.py
+++ b/pkgs/stringdump.py
@@ -72,19 +72,14 @@ class StringDump:
         return finalStringList
 
     def dumpStringsToTempFile(self, filePath):
-        try:
-            finalStringList = self.__removeBlackListStrings(self.__getStrings(filePath))
+        finalStringList = self.__removeBlackListStrings(self.__getStrings(filePath))
 
-            if not os.path.exists(self.tempFolder):
-                os.makedirs(self.tempFolder)
+        if not os.path.exists(self.tempFolder):
+            os.makedirs(self.tempFolder)
 
-            fileName = splitDirFileName(filePath)[1]
-            tempFile = os.path.join(self.tempFolder,fileName.replace(".","-"))
-            with open(tempFile, 'w') as filePointer:
-                for str in finalStringList:
-                    filePointer.write(str+"\n")
-            filePointer.close()
-
-        except Exception as error:
-            raise Exception(error)
-            sys.exit(1)
+        fileName = splitDirFileName(filePath)[1]
+        tempFile = os.path.join(self.tempFolder,fileName.replace(".","-"))
+        with open(tempFile, 'w') as filePointer:
+            for str in finalStringList:
+                filePointer.write(str+"\n")
+        filePointer.close()


### PR DESCRIPTION
🎯 **What:** Removed the redundant `try...except` block in `pkgs/stringdump.py`'s `dumpStringsToTempFile` method which simply caught exceptions, wrapped them in a generic `Exception`, and attempted to call an unreachable `sys.exit(1)`.

💡 **Why:** The original error is now allowed to cleanly propagate without being wrapped inside a generic exception without context. This improves the maintainability and debuggability of the code by maintaining the original exception type and full stack trace. The `sys.exit(1)` was already unreachable code (placed directly after a `raise` statement) so it's removal doesn't affect behavior.

✅ **Verification:** Verified the removal visually and via tests. Also ran the full pytest suite (`python -m pytest tests`), resulting in all tests passing. The change was validated for safety as it effectively maintains equivalent functionality (exceptions are still propagated) but in a cleaner way.

✨ **Result:** The codebase is cleaner and any errors occurring during the temp file string dump will now provide proper context in their stack traces.

---
*PR created automatically by Jules for task [3570922091860702665](https://jules.google.com/task/3570922091860702665) started by @himadriganguly*