### PR TITLE
🧹 [code health improvement] Remove unreachable sys.exit after raise Exception

### DIFF
--- a/pkgs/findfiles.py
+++ b/pkgs/findfiles.py
@@ -39,4 +39,3 @@ class FindFiles:
 
         except Exception as error:
             raise Exception(error)
-            sys.exit(1)

--- a/pkgs/fuzzymatch.py
+++ b/pkgs/fuzzymatch.py
@@ -71,4 +71,3 @@ class FuzzyMatch:
             print("\n")
         except Exception as error:
             raise Exception(error)
-            sys.exit(1)

--- a/pkgs/searchpattern.py
+++ b/pkgs/searchpattern.py
@@ -68,4 +68,3 @@ class SearchPattern:
             return(self.foundPattern)
         except Exception as error:
             raise Exception(error)
-            sys.exit(1)

--- a/pkgs/stringdump.py
+++ b/pkgs/stringdump.py
@@ -87,4 +87,3 @@ class StringDump:
 
         except Exception as error:
             raise Exception(error)
-            sys.exit(1)


### PR DESCRIPTION
🎯 **What:** Removed unreachable `sys.exit(1)` statements that immediately followed `raise Exception()` calls in `pkgs/fuzzymatch.py`, `pkgs/searchpattern.py`, `pkgs/findfiles.py`, and `pkgs/stringdump.py`.

💡 **Why:** When an exception is raised, the normal execution flow is immediately terminated and control is passed to the nearest enclosing `try/except` block or out of the function entirely. Therefore, any code placed directly after a `raise` statement is dead code and will never be executed. Removing this unreachable code improves the maintainability and readability of the codebase by eliminating unnecessary and misleading lines. 

✅ **Verification:**
1. Confirmed the structure of the `try...except` blocks in all affected files.
2. Verified the edits successfully applied by reading the last few lines of each modified file.
3. Successfully executed the test suite (`python -m pytest tests`), with all 9 tests passing, verifying no functionality was broken. 
4. The valid `sys.exit(1)` call in `pkgs/stringdump.py` (which did not follow an exception) was kept intact.

✨ **Result:** A cleaner, more maintainable codebase free of dead code in error handling blocks, keeping functionality exactly the same.

---
*PR created automatically by Jules for task [11197340425698664392](https://jules.google.com/task/11197340425698664392) started by @himadriganguly*