### PR TITLE
🧹 [Remove unnecessary exception wrapping]

### DIFF
--- a/pkgs/findfiles.py
+++ b/pkgs/findfiles.py
@@ -37,6 +37,5 @@ class FindFiles:
                     yield filePath
             print("\n")
 
-        except Exception as error:
-            raise Exception(error)
-            sys.exit(1)
+        except Exception:
+            raise

--- a/pkgs/fuzzymatch.py
+++ b/pkgs/fuzzymatch.py
@@ -69,6 +69,5 @@ class FuzzyMatch:
                                 shutil.copy(traverseFilePath, self.inputFilesPath)
                                 break
             print("\n")
-        except Exception as error:
-            raise Exception(error)
-            sys.exit(1)
+        except Exception:
+            raise

--- a/pkgs/searchpattern.py
+++ b/pkgs/searchpattern.py
@@ -66,6 +66,5 @@ class SearchPattern:
             writeFilePointer.close()
             print("\n")
             return(self.foundPattern)
-        except Exception as error:
-            raise Exception(error)
-            sys.exit(1)
+        except Exception:
+            raise

--- a/pkgs/stringdump.py
+++ b/pkgs/stringdump.py
@@ -85,6 +85,5 @@ class StringDump:
                     filePointer.write(str+"\n")
             filePointer.close()
 
-        except Exception as error:
-            raise Exception(error)
-            sys.exit(1)
+        except Exception:
+            raise


### PR DESCRIPTION
🎯 **What:** Removed unnecessary exception wrapping in `pkgs/fuzzymatch.py`, `pkgs/searchpattern.py`, `pkgs/findfiles.py`, and `pkgs/stringdump.py`.
💡 **Why:** Raising a new generic `Exception` from an existing one obscures the original stack trace and context. Removing this wrapping and using bare `raise` improves maintainability by preserving the traceback, while additionally eliminating unreachable `sys.exit(1)` dead code blocks.
✅ **Verification:** Ran `python -m pytest tests` successfully ensuring no functional regressions were introduced.
✨ **Result:** Cleaned up code health anti-patterns, improving debuggability and maintaining the intended control flow behavior.

---
*PR created automatically by Jules for task [15987414417806533064](https://jules.google.com/task/15987414417806533064) started by @himadriganguly*