### PR TITLE
🧹 Remove unreachable sys.exit after raise Exception in stringdump.py

### DIFF
--- a/pkgs/stringdump.py
+++ b/pkgs/stringdump.py
@@ -87,4 +87,3 @@ class StringDump:
 
         except Exception as error:
             raise Exception(error)
-            sys.exit(1)


### PR DESCRIPTION
🎯 **What:** Removed the unreachable `sys.exit(1)` call in the `dumpStringsToTempFile` method of `pkgs/stringdump.py`.
💡 **Why:** The code immediately following `raise Exception(error)` is completely unreachable. Removing it cleans up dead code and improves readability by avoiding confusion on error flow semantics. 
✅ **Verification:** Verified the code change and ran `python -m pytest tests`, which passed all unit tests (9/9 passed).
✨ **Result:** Cleaned up the codebase by removing dead, unreachable lines, improving maintainability without changing any functionality.

---
*PR created automatically by Jules for task [16497329762167184441](https://jules.google.com/task/16497329762167184441) started by @himadriganguly*