### PR TITLE
🧹 Remove unused import in fuzzymatch.py

### DIFF
--- a/pkgs/fuzzymatch.py
+++ b/pkgs/fuzzymatch.py
@@ -1,4 +1,4 @@
-import os, time, random, ppdeep, shutil
+import os, random, ppdeep, shutil
 from tqdm import tqdm
 
 from pkgs.utils import listdir


### PR DESCRIPTION
🎯 **What:** Removed the unused `time` import from `pkgs/fuzzymatch.py`.
💡 **Why:** The `time` module was imported but never used in the file. Removing it improves code health, readability, and slightly reduces unnecessary module loading.
✅ **Verification:** Ran `python -m pytest tests` and all 9 tests passed. Also verified using `grep` that `time` is no longer imported and no other code relied on it.
✨ **Result:** A cleaner import statement in `pkgs/fuzzymatch.py` without any loss of functionality.

---
*PR created automatically by Jules for task [6606684549799089200](https://jules.google.com/task/6606684549799089200) started by @himadriganguly*