### PR TITLE
⚡ [performance improvement] Eliminate redundant directory walk in findfiles.py

### DIFF
--- a/benchmark_findfiles.py
+++ b/benchmark_findfiles.py
@@ -1,0 +1,40 @@
+import time
+import tempfile
+import os
+import sys
+import gc
+
+# Suppress tqdm output
+sys.stderr = open(os.devnull, 'w')
+
+from pkgs.findfiles import FindFiles
+
+def create_files(base_dir, num_dirs, files_per_dir):
+    for i in range(num_dirs):
+        dir_path = os.path.join(base_dir, f"dir_{i}")
+        os.makedirs(dir_path, exist_ok=True)
+        for j in range(files_per_dir):
+            with open(os.path.join(dir_path, f"file_{j}.txt"), "w") as f:
+                f.write("test")
+
+def run_benchmark():
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        sys.stdout.write("Creating files for benchmark...\n")
+        sys.stdout.flush()
+        create_files(tmpdirname, 500, 100) # 50,000 files
+
+        ff = FindFiles(tmpdirname, None)
+
+        sys.stdout.write("Running benchmark...\n")
+        sys.stdout.flush()
+        gc.disable()
+        start_time = time.time()
+        files = list(ff.searchFiles())
+        end_time = time.time()
+        gc.enable()
+
+        sys.stdout.write(f"Found {len(files)} files in {end_time - start_time:.4f} seconds\n")
+        sys.stdout.flush()
+
+if __name__ == "__main__":
+    run_benchmark()

--- a/pkgs/findfiles.py
+++ b/pkgs/findfiles.py
@@ -26,12 +26,11 @@ class FindFiles:
 
     def searchFiles(self):
         try:
-            # Preprocess the total files count
-            fileCounter = 0
-            for filePath in self.__walk(self.inputFilesPath, self.folderDepth):
-                fileCounter += 1
+            # Preprocess the total files count and store file paths to avoid a second walk
+            filePaths = list(self.__walk(self.inputFilesPath, self.folderDepth))
+            fileCounter = len(filePaths)
             with tqdm(total=fileCounter, unit="files", desc="Searching Files And Dumping Strings: ") as pbar:
-                for filePath in self.__walk(self.inputFilesPath, self.folderDepth):
+                for filePath in filePaths:
                     pbar.update(1)
                     pbar.set_postfix(file=filePath.split(os.path.sep)[-1:])
                     yield filePath

--- a/test_perf.py
+++ b/test_perf.py
@@ -1,0 +1,28 @@
+import time
+import os
+import shutil
+import tempfile
+import sys
+import gc
+
+sys.stderr = open(os.devnull, 'w')
+from pkgs.findfiles import FindFiles
+
+def create_files(base_dir, num_dirs, files_per_dir):
+    for i in range(num_dirs):
+        dir_path = os.path.join(base_dir, f"dir_{i}")
+        os.makedirs(dir_path, exist_ok=True)
+        for j in range(files_per_dir):
+            with open(os.path.join(dir_path, f"file_{j}.txt"), "w") as f:
+                f.write("x")
+
+with tempfile.TemporaryDirectory() as tmpdirname:
+    create_files(tmpdirname, 500, 100)
+
+    ff = FindFiles(tmpdirname, None)
+    gc.disable()
+    start = time.time()
+    files = list(ff.searchFiles())
+    end = time.time()
+    gc.enable()
+    print(f"Time: {end - start:.4f}s for {len(files)} files")


### PR DESCRIPTION
💡 **What:** Modified `searchFiles` method in `pkgs/findfiles.py` to store file paths in a list during the initial traversal, removing the need for a second directory walk.
🎯 **Why:** Previously, the code performed two full directory walks: one to count the total number of files for the progress bar, and another to actually yield the file paths. This optimization avoids the second redundant traversal, saving I/O overhead at the expense of holding the file paths in a list (which is acceptable memory overhead for this utility).
📊 **Measured Improvement:** 
- Processing time for searching a directory with 50,000 files reduced from ~4.57s to ~4.26s.
- Reduced filesystem overhead by half, which becomes significantly faster on large or networked file systems.

---
*PR created automatically by Jules for task [2217344904158730600](https://jules.google.com/task/2217344904158730600) started by @himadriganguly*