### PR TITLE
🧹 [Remove unreachable sys.exit(1)]

### DIFF
--- a/pkgs/findfiles.py
+++ b/pkgs/findfiles.py
@@ -39,4 +39,3 @@ class FindFiles:
 
         except Exception as error:
             raise Exception(error)
-            sys.exit(1)

--- a/pkgs/fuzzymatch.py
+++ b/pkgs/fuzzymatch.py
@@ -71,4 +71,3 @@ class FuzzyMatch:
             print("\n")
         except Exception as error:
             raise Exception(error)
-            sys.exit(1)

--- a/pkgs/searchpattern.py
+++ b/pkgs/searchpattern.py
@@ -68,4 +68,3 @@ class SearchPattern:
             return(self.foundPattern)
         except Exception as error:
             raise Exception(error)
-            sys.exit(1)

--- a/pkgs/stringdump.py
+++ b/pkgs/stringdump.py
@@ -87,4 +87,3 @@ class StringDump:
 
         except Exception as error:
             raise Exception(error)
-            sys.exit(1)


### PR DESCRIPTION
🎯 **What:** Removed `sys.exit(1)` statements that immediately followed `raise Exception(error)` in `pkgs/searchpattern.py`, `pkgs/fuzzymatch.py`, `pkgs/findfiles.py`, and `pkgs/stringdump.py`.

💡 **Why:** The code explicitly raised an Exception, meaning the next line (`sys.exit`) would never be reached. Removing it cleans up dead code, improves readability, and adheres to the pattern that library code should raise exceptions rather than exiting the application directly.

✅ **Verification:** Verified by using `read_file` (via `cat` and `grep`) to inspect that the unreachable `sys.exit(1)` was removed successfully, while keeping a valid/reachable `sys.exit(1)` in `stringdump.py`. Then, ran the full test suite with `python -m pytest tests`, where all 9 tests passed successfully. Code review confirmed the fix is complete, safe, and without regressions.

✨ **Result:** Dead code is eliminated, making the error-handling blocks cleaner and correctly communicating that exceptions propagate outwards.

---
*PR created automatically by Jules for task [13523203505933779988](https://jules.google.com/task/13523203505933779988) started by @himadriganguly*