### PR TITLE
🔒 [security] Fix missing Jinja2 autoescaping by implementing manual input sanitization

### DIFF
--- a/yarasilly2.py
+++ b/yarasilly2.py
@@ -39,7 +39,7 @@ def main(rulename=None, filetype=None, matchpatternfile=None, inputfilepath=None
         sys.exit(1)
 
     fileLoader = FileSystemLoader('templates')
-    env = Environment(loader=fileLoader)
+    env = Environment(loader=fileLoader, autoescape=False) # nosec B701
     yaraTemplate = env.get_template('default.yar')
 
     try:
@@ -110,13 +110,19 @@ def main(rulename=None, filetype=None, matchpatternfile=None, inputfilepath=None
 
         shutil.rmtree(tempFolder)
 
+        # Sanitize user inputs to prevent template injection
+        def sanitize(s):
+            if not s:
+                return s
+            return str(s).replace('\\', '\\\\').replace('"', '\\"').replace('\n', ' ').replace('\r', ' ')
+
         if(foundPattern):
             templateValDict = {
-                "ruleName": rulename,
-                "ruleTag": tags,
-                "authorName": author,
+                "ruleName": rulename, # Rule name already regex-checked
+                "ruleTag": sanitize(tags),
+                "authorName": sanitize(author),
                 "date": datetime.now().strftime("%Y-%m-%d"),
-                "desc": description,
+                "desc": sanitize(description),
                 "hashArray": fileHash,
                 "fileType": "office"
             }


### PR DESCRIPTION
🎯 **What:** The Jinja2 `Environment` was initialized without explicit autoescaping enabled, which was flagged as a potential vulnerability (Bandit B701).

⚠️ **Risk:** While the generated output is a YARA rule (not HTML/XML), failing to sanitize user inputs (like `tags`, `author`, and `description`) could allow an attacker to inject arbitrary strings or conditions into the resulting `.yar` file, potentially corrupting the generated rule or maliciously altering its logic (YARA template injection).

🛡️ **Solution:**
- Explicitly configured the Jinja2 `Environment` with `autoescape=False` and suppressed the linter warning using `# nosec B701`. This is necessary because Jinja's built-in HTML autoescaping would corrupt the YARA syntax.
- Implemented a custom `sanitize()` function to manually secure the user-supplied variables by escaping backslashes and double quotes, and stripping out newlines before they are passed to the template. This prevents attackers from "breaking out" of string boundaries inside the generated `.yar` rule.

---
*PR created automatically by Jules for task [1743687026409843283](https://jules.google.com/task/1743687026409843283) started by @himadriganguly*