### PR TITLE
🧪 [testing improvement] Add missing test for StringDump no extractable attributes

### DIFF
--- a/tests/test_stringdump.py
+++ b/tests/test_stringdump.py
@@ -17,3 +17,19 @@ def test_stringdump_getstrings():
 
         # Test url extraction
         assert any("http://example.com" in s for s in strings if isinstance(s, str))
+
+def test_stringdump_getstrings_no_attributes(mocker):
+    with tempfile.TemporaryDirectory() as tempFolder:
+        file1 = os.path.join(tempFolder, "file1_empty")
+        with open(file1, 'w') as f:
+            f.write("")
+
+        sd = StringDump(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'office', tempFolder, blocksize=1024)
+        mock_puts = mocker.patch("pkgs.stringdump.puts")
+
+        with pytest.raises(SystemExit) as exc:
+            sd._StringDump__getStrings(file1)
+
+        assert exc.value.code == 1
+        mock_puts.assert_called_once()
+        assert "No Extractable Attributes Present in" in str(mock_puts.call_args[0][0])


### PR DESCRIPTION
🎯 **What:** The testing gap addressed is the lack of test coverage for the error condition in `pkgs.stringdump.StringDump._StringDump__getStrings` where a file has no extractable string attributes.
📊 **Coverage:** The scenario where a file contains no extractable attributes is now tested, and verifies that the process exits with `SystemExit(1)` and properly outputs an error message using `puts`.
✨ **Result:** Test coverage for `pkgs/stringdump.py` increased. The error path that exits when there are no strings is now fully covered, adding confidence and preventing future regressions in this logic.

---
*PR created automatically by Jules for task [16411518270988720500](https://jules.google.com/task/16411518270988720500) started by @himadriganguly*