### PR TITLE
🧹 [code health improvement] Remove unreachable sys.exit()

### DIFF
--- a/pkgs/findfiles.py
+++ b/pkgs/findfiles.py
@@ -39,4 +39,3 @@ class FindFiles:
 
         except Exception as error:
             raise Exception(error)
-            sys.exit(1)


### PR DESCRIPTION
🎯 **What:** Removed the unreachable `sys.exit(1)` statement in `pkgs/findfiles.py`.
💡 **Why:** The code explicitly raised an `Exception` right before `sys.exit(1)`, making the `sys.exit(1)` line dead code. Removing it improves codebase maintainability and reduces clutter, leaving the exception handling standard intact (propagating errors correctly).
✅ **Verification:** I successfully ran the full `pytest` test suite, which passed completely (9 tests) with no regressions, confirming that removing the dead code has no adverse runtime effects.
✨ **Result:** The codebase is cleaner and adheres better to Python error propagation principles without unreachable code warnings.

---
*PR created automatically by Jules for task [6017726629659634124](https://jules.google.com/task/6017726629659634124) started by @himadriganguly*