### PR TITLE
🧹 [Remove unused tqdm import]

### DIFF
--- a/pkgs/stringdump.py
+++ b/pkgs/stringdump.py
@@ -1,6 +1,5 @@
 import re, sys, os
 from clint.textui import puts, colored
-from tqdm import tqdm
 
 from pkgs.utils import md5sum
 from pkgs.utils import splitDirFileName


### PR DESCRIPTION
🎯 **What:** Removed unused `from tqdm import tqdm` import from `pkgs/stringdump.py`.
💡 **Why:** This improves the code health by cleaning up dead code and avoids importing unneeded libraries.
✅ **Verification:** Ran `python -m pytest tests/` to confirm that tests still pass, meaning no functionality has been broken.
✨ **Result:** A cleaner codebase with fewer unused dependencies being loaded in `pkgs/stringdump.py`.

---
*PR created automatically by Jules for task [3120094756807036478](https://jules.google.com/task/3120094756807036478) started by @himadriganguly*