### PR TITLE
🧹 [Code Health] Remove unused time import and unreachable code in findfiles.py

### DIFF
--- a/pkgs/findfiles.py
+++ b/pkgs/findfiles.py
@@ -1,4 +1,4 @@
-import os, time
+import os
 from tqdm import tqdm
 
 from pkgs.utils import listdir
@@ -39,4 +39,3 @@ class FindFiles:
 
         except Exception as error:
             raise Exception(error)
-            sys.exit(1)


### PR DESCRIPTION
🎯 **What:** Removed the unused `time` import and the unreachable `sys.exit(1)` code in `pkgs/findfiles.py`.
💡 **Why:** To improve code health and maintainability by removing unused and unreachable code.
✅ **Verification:** Verified the code changes using `cat pkgs/findfiles.py` and ran the project's test suite to ensure no regressions were introduced.
✨ **Result:** A cleaner `pkgs/findfiles.py` file with no unused imports or unreachable code.

---
*PR created automatically by Jules for task [10193022823592250117](https://jules.google.com/task/10193022823592250117) started by @himadriganguly*