### PR TITLE
🧹 [Code Health] Remove unnecessary exception wrapping from library modules

### DIFF
--- a/pkgs/findfiles.py
+++ b/pkgs/findfiles.py
@@ -25,18 +25,13 @@ class FindFiles:
                         yield os.path.join(dirpath, filename)
 
     def searchFiles(self):
-        try:
-            # Preprocess the total files count
-            fileCounter = 0
+        # Preprocess the total files count
+        fileCounter = 0
+        for filePath in self.__walk(self.inputFilesPath, self.folderDepth):
+            fileCounter += 1
+        with tqdm(total=fileCounter, unit="files", desc="Searching Files And Dumping Strings: ") as pbar:
             for filePath in self.__walk(self.inputFilesPath, self.folderDepth):
-                fileCounter += 1
-            with tqdm(total=fileCounter, unit="files", desc="Searching Files And Dumping Strings: ") as pbar:
-                for filePath in self.__walk(self.inputFilesPath, self.folderDepth):
-                    pbar.update(1)
-                    pbar.set_postfix(file=filePath.split(os.path.sep)[-1:])
-                    yield filePath
-            print("\n")
-
-        except Exception as error:
-            raise Exception(error)
-            sys.exit(1)
+                pbar.update(1)
+                pbar.set_postfix(file=filePath.split(os.path.sep)[-1:])
+                yield filePath
+        print("\n")

--- a/pkgs/fuzzymatch.py
+++ b/pkgs/fuzzymatch.py
@@ -15,60 +15,56 @@ class FuzzyMatch:
         self.inputFilesPath = inputFilesPath
 
     def searchFiles(self):
-        try:
-            if os.listdir(self.confirmPath):
-                fileName = random.choice(os.listdir(self.confirmPath))
-                filePath = os.path.join(self.confirmPath, fileName)
-            else:
-                raise Exception("Empty confirm virus sample folder.")
+        if os.listdir(self.confirmPath):
+            fileName = random.choice(os.listdir(self.confirmPath))
+            filePath = os.path.join(self.confirmPath, fileName)
+        else:
+            raise Exception("Empty confirm virus sample folder.")
 
-            print("Reference File For Fuzzy Hash: {}".format(filePath))
-            refHash = ppdeep.hash_from_file(filePath)
-            print("Fuzzy Hash Of Reference File: {}\n".format(refHash))
-            # Preprocess the total files count
-            fileCounter = 0
-            for filePath in listdir(self.confirmPath):
-                fileCounter += 1
+        print("Reference File For Fuzzy Hash: {}".format(filePath))
+        refHash = ppdeep.hash_from_file(filePath)
+        print("Fuzzy Hash Of Reference File: {}\n".format(refHash))
+        # Preprocess the total files count
+        fileCounter = 0
+        for filePath in listdir(self.confirmPath):
+            fileCounter += 1
 
-            if fileCounter == 1:
-                self.confirmPathFileHash.append(refHash)
-                shutil.copy(filePath, self.inputFilesPath)
-            else:
-                with tqdm(total=fileCounter, unit="files", desc="Fuzzy find in confirm path: ") as pbar:
-                    for traverseFilePath in listdir(self.confirmPath):
-                        pbar.update(1)
-                        pbar.set_postfix(file=filePath.split(os.path.sep)[-1:])
-                        if filePath == traverseFilePath:
-                            self.confirmPathFileHash.append(refHash)
-                            shutil.copy(traverseFilePath, self.inputFilesPath)
-                            continue
-                        tmpHash = ppdeep.hash_from_file(traverseFilePath)
+        if fileCounter == 1:
+            self.confirmPathFileHash.append(refHash)
+            shutil.copy(filePath, self.inputFilesPath)
+        else:
+            with tqdm(total=fileCounter, unit="files", desc="Fuzzy find in confirm path: ") as pbar:
+                for traverseFilePath in listdir(self.confirmPath):
+                    pbar.update(1)
+                    pbar.set_postfix(file=filePath.split(os.path.sep)[-1:])
+                    if filePath == traverseFilePath:
+                        self.confirmPathFileHash.append(refHash)
+                        shutil.copy(traverseFilePath, self.inputFilesPath)
+                        continue
+                    tmpHash = ppdeep.hash_from_file(traverseFilePath)
+                    # print("File: ", traverseFilePath, " - ", ppdeep.compare(refHash, tmpHash))
+                    if ppdeep.compare(refHash, tmpHash) >= self.confirmFilesPercent:
+                        self.confirmPathFileHash.append(tmpHash)
+                        shutil.copy(traverseFilePath, self.inputFilesPath)
+                    else:
+                        shutil.copy(traverseFilePath, self.probablePath)
+        print("\n")
+
+        fileCounter = 0
+        for filePath in listdir(self.probablePath):
+            fileCounter += 1
+
+        if fileCounter == 0:
+            raise Exception("Empty probable virus sample folder.")
+        else:
+            with tqdm(total=fileCounter, unit="files", desc="Fuzzy find in probable path: ") as pbar:
+                for traverseFilePath in listdir(self.probablePath):
+                    pbar.update(1)
+                    pbar.set_postfix(file=filePath.split(os.path.sep)[-1:])
+                    tmpHash = ppdeep.hash_from_file(traverseFilePath)
+                    for fileHash in self.confirmPathFileHash:
                         # print("File: ", traverseFilePath, " - ", ppdeep.compare(refHash, tmpHash))
-                        if ppdeep.compare(refHash, tmpHash) >= self.confirmFilesPercent:
-                            self.confirmPathFileHash.append(tmpHash)
+                        if ppdeep.compare(fileHash, tmpHash) >= self.probableFilesPercent:
                             shutil.copy(traverseFilePath, self.inputFilesPath)
-                        else:
-                            shutil.copy(traverseFilePath, self.probablePath)
-            print("\n")
-
-            fileCounter = 0
-            for filePath in listdir(self.probablePath):
-                fileCounter += 1
-
-            if fileCounter == 0:
-                raise Exception("Empty probable virus sample folder.")
-            else:
-                with tqdm(total=fileCounter, unit="files", desc="Fuzzy find in probable path: ") as pbar:
-                    for traverseFilePath in listdir(self.probablePath):
-                        pbar.update(1)
-                        pbar.set_postfix(file=filePath.split(os.path.sep)[-1:])
-                        tmpHash = ppdeep.hash_from_file(traverseFilePath)
-                        for fileHash in self.confirmPathFileHash:
-                            # print("File: ", traverseFilePath, " - ", ppdeep.compare(refHash, tmpHash))
-                            if ppdeep.compare(fileHash, tmpHash) >= self.probableFilesPercent:
-                                shutil.copy(traverseFilePath, self.inputFilesPath)
-                                break
-            print("\n")
-        except Exception as error:
-            raise Exception(error)
-            sys.exit(1)
+                            break
+        print("\n")

--- a/pkgs/searchpattern.py
+++ b/pkgs/searchpattern.py
@@ -38,34 +38,30 @@ class SearchPattern:
         return count
 
     def search(self, file):
-        try:
-            # Preprocess the total file size
-            sizeCounter = os.stat(file).st_size
+        # Preprocess the total file size
+        sizeCounter = os.stat(file).st_size
 
-            writeFilePointer = open(self.matchPatternFilePath, 'w+')
+        writeFilePointer = open(self.matchPatternFilePath, 'w+')
 
-            with tqdm(total=sizeCounter,
-                      unit='B', unit_scale=True, unit_divisor=1024, desc="Searching For Pattern Match: ") as pbar:
-                with open(file, 'r') as filePointer:
-                    buf = 1
-                    while (buf):
-                        buf = filePointer.read(self.blocksize)
-                        for stringPattern in buf.splitlines():
-                            if not stringPattern.strip():
-                                continue
-                            if self.__checkPatternPresent(writeFilePointer, stringPattern):
-                                match = self.__checkIfStringInFile(file, stringPattern)
-                                if match>=self.occurance:
-                                    self.foundPattern = 1
-                                    writeFilePointer.seek(0, 2)
-                                    writeFilePointer.write(str(match) + "-" + stringPattern.strip() + "\n")
-                        if buf:
-                            pbar.set_postfix(file=file)
-                            pbar.update(len(buf))
-                filePointer.close()
-            writeFilePointer.close()
-            print("\n")
-            return(self.foundPattern)
-        except Exception as error:
-            raise Exception(error)
-            sys.exit(1)
+        with tqdm(total=sizeCounter,
+                  unit='B', unit_scale=True, unit_divisor=1024, desc="Searching For Pattern Match: ") as pbar:
+            with open(file, 'r') as filePointer:
+                buf = 1
+                while (buf):
+                    buf = filePointer.read(self.blocksize)
+                    for stringPattern in buf.splitlines():
+                        if not stringPattern.strip():
+                            continue
+                        if self.__checkPatternPresent(writeFilePointer, stringPattern):
+                            match = self.__checkIfStringInFile(file, stringPattern)
+                            if match>=self.occurance:
+                                self.foundPattern = 1
+                                writeFilePointer.seek(0, 2)
+                                writeFilePointer.write(str(match) + "-" + stringPattern.strip() + "\n")
+                    if buf:
+                        pbar.set_postfix(file=file)
+                        pbar.update(len(buf))
+            filePointer.close()
+        writeFilePointer.close()
+        print("\n")
+        return(self.foundPattern)

--- a/pkgs/stringdump.py
+++ b/pkgs/stringdump.py
@@ -72,19 +72,14 @@ class StringDump:
         return finalStringList
 
     def dumpStringsToTempFile(self, filePath):
-        try:
-            finalStringList = self.__removeBlackListStrings(self.__getStrings(filePath))
+        finalStringList = self.__removeBlackListStrings(self.__getStrings(filePath))
 
-            if not os.path.exists(self.tempFolder):
-                os.makedirs(self.tempFolder)
+        if not os.path.exists(self.tempFolder):
+            os.makedirs(self.tempFolder)
 
-            fileName = splitDirFileName(filePath)[1]
-            tempFile = os.path.join(self.tempFolder,fileName.replace(".","-"))
-            with open(tempFile, 'w') as filePointer:
-                for str in finalStringList:
-                    filePointer.write(str+"\n")
-            filePointer.close()
-
-        except Exception as error:
-            raise Exception(error)
-            sys.exit(1)
+        fileName = splitDirFileName(filePath)[1]
+        tempFile = os.path.join(self.tempFolder,fileName.replace(".","-"))
+        with open(tempFile, 'w') as filePointer:
+            for str in finalStringList:
+                filePointer.write(str+"\n")
+        filePointer.close()


### PR DESCRIPTION
🎯 **What:** Removed unnecessary `try...except Exception as error:` blocks that caught exceptions, re-raised them as generic `Exception`s, and followed with unreachable `sys.exit(1)` calls. This was applied consistently across `pkgs/findfiles.py`, `pkgs/fuzzymatch.py`, `pkgs/searchpattern.py`, and `pkgs/stringdump.py`.

💡 **Why:** Catching specific errors and re-raising them as generic `Exception` objects destroys original stack traces and type context (e.g., `FileNotFoundError`), making debugging harder. Furthermore, calling `sys.exit(1)` immediately after a `raise` statement is dead code since execution stops at the exception. Finally, library code should generally raise exceptions rather than forcing the application to exit.

✅ **Verification:**
1. Modified the source files using targeted text replacement.
2. Verified the unindentation was correct using `sed`.
3. Ran `python3 -m pytest -v tests/` to confirm the test suite still passes without regressions.

✨ **Result:** A cleaner codebase where errors surface natively with their correct types and original stack traces, improving maintainability and debuggability while adhering to standard Python exception propagation patterns.

---
*PR created automatically by Jules for task [2605736446259069464](https://jules.google.com/task/2605736446259069464) started by @himadriganguly*