### PR TITLE
🔒 [Remove catch-all exception and unreachable sys.exit in pkgs/stringdump.py]

### DIFF
--- a/pkgs/stringdump.py
+++ b/pkgs/stringdump.py
@@ -72,19 +72,14 @@ class StringDump:
         return finalStringList
 
     def dumpStringsToTempFile(self, filePath):
-        try:
-            finalStringList = self.__removeBlackListStrings(self.__getStrings(filePath))
+        finalStringList = self.__removeBlackListStrings(self.__getStrings(filePath))
 
-            if not os.path.exists(self.tempFolder):
-                os.makedirs(self.tempFolder)
+        if not os.path.exists(self.tempFolder):
+            os.makedirs(self.tempFolder)
 
-            fileName = splitDirFileName(filePath)[1]
-            tempFile = os.path.join(self.tempFolder,fileName.replace(".","-"))
-            with open(tempFile, 'w') as filePointer:
-                for str in finalStringList:
-                    filePointer.write(str+"\n")
-            filePointer.close()
-
-        except Exception as error:
-            raise Exception(error)
-            sys.exit(1)
+        fileName = splitDirFileName(filePath)[1]
+        tempFile = os.path.join(self.tempFolder,fileName.replace(".","-"))
+        with open(tempFile, 'w') as filePointer:
+            for str in finalStringList:
+                filePointer.write(str+"\n")
+        filePointer.close()


### PR DESCRIPTION
🎯 **What:** Removed the `try...except Exception as error:` block and unreachable `sys.exit(1)` from `pkgs/stringdump.py`'s `dumpStringsToTempFile` method.

⚠️ **Risk:** Catching all exceptions with a generic `Exception` swallows the original stack trace and masks potential errors underneath, making it significantly harder to debug failures. Furthermore, the `sys.exit(1)` call was completely unreachable since the `raise` statement interrupted the flow before it. Finally, `sys.exit(1)` inside library modules (`pkgs/`) is a bad practice since it forces the entire application to terminate abruptly rather than letting the CLI entrypoint handle the error appropriately.

🛡️ **Solution:** Removed the `try...except` block completely. Allowing exceptions to naturally propagate is the standard Python practice for exceptions we aren't deliberately handling or suppressing, ensuring standard tools and CLI entrypoints can catch and trace them correctly.

---
*PR created automatically by Jules for task [3732941360911558691](https://jules.google.com/task/3732941360911558691) started by @himadriganguly*