### PR TITLE
🧹 [code health improvement] Remove commented-out print in fuzzymatch.py

### DIFF
--- a/pkgs/fuzzymatch.py
+++ b/pkgs/fuzzymatch.py
@@ -42,7 +42,6 @@ class FuzzyMatch:
                         shutil.copy(traverseFilePath, self.inputFilesPath)
                         continue
                     tmpHash = ppdeep.hash_from_file(traverseFilePath)
-                    # print("File: ", traverseFilePath, " - ", ppdeep.compare(refHash, tmpHash))
                     if ppdeep.compare(refHash, tmpHash) >= self.confirmFilesPercent:
                         self.confirmPathFileHash.append(tmpHash)
                         shutil.copy(traverseFilePath, self.inputFilesPath)


### PR DESCRIPTION
🎯 **What:** Removed a commented-out print statement from the `searchFiles` method in `pkgs/fuzzymatch.py`.
💡 **Why:** The commented-out code served no purpose and cluttering the codebase. Removing it improves readability and maintainability.
✅ **Verification:** Verified the code removal manually. Ran the relevant unit tests (`pytest tests/test_fuzzymatch.py`) to confirm no functionality was affected. Note that there are pre-existing test failures in other modules, but none are related to this change.
✨ **Result:** A cleaner, more readable `searchFiles` method without unnecessary comments.

---
*PR created automatically by Jules for task [2549495370144123196](https://jules.google.com/task/2549495370144123196) started by @himadriganguly*