### PR TITLE
🧹 [code health improvement] Remove commented-out prints in FuzzyMatch

### DIFF
--- a/pkgs/fuzzymatch.py
+++ b/pkgs/fuzzymatch.py
@@ -42,7 +42,6 @@ class FuzzyMatch:
                         shutil.copy(traverseFilePath, self.inputFilesPath)
                         continue
                     tmpHash = ppdeep.hash_from_file(traverseFilePath)
-                    # print("File: ", traverseFilePath, " - ", ppdeep.compare(refHash, tmpHash))
                     if ppdeep.compare(refHash, tmpHash) >= self.confirmFilesPercent:
                         self.confirmPathFileHash.append(tmpHash)
                         shutil.copy(traverseFilePath, self.inputFilesPath)
@@ -63,7 +62,6 @@ class FuzzyMatch:
                     pbar.set_postfix(file=filePath.split(os.path.sep)[-1:])
                     tmpHash = ppdeep.hash_from_file(traverseFilePath)
                     for fileHash in self.confirmPathFileHash:
-                        # print("File: ", traverseFilePath, " - ", ppdeep.compare(refHash, tmpHash))
                         if ppdeep.compare(fileHash, tmpHash) >= self.probableFilesPercent:
                             shutil.copy(traverseFilePath, self.inputFilesPath)
                             break


### PR DESCRIPTION
🎯 **What:** Removed commented-out `# print` statements that output `traverseFilePath` and fuzzy hashes during file comparison loops inside `pkgs/fuzzymatch.py`.
💡 **Why:** This dead code serves no active purpose, cluttering the file and reducing readability. Its removal adheres to general codebase cleanliness and maintainability practices.
✅ **Verification:** Verified changes via `read_file` and ensured no regressions were introduced by running `python -m pytest tests` (any failing tests are pre-existing). The changes were also manually confirmed through a local code review request tool which assessed it as safe and correct.
✨ **Result:** A cleaner `FuzzyMatch` module with fewer irrelevant comments and better overall code health.

---
*PR created automatically by Jules for task [14491102809768018345](https://jules.google.com/task/14491102809768018345) started by @himadriganguly*