### PR TITLE
🔒 Fix SSTI vulnerability in Jinja2 template rendering

### DIFF
--- a/pkgs/searchpattern.py
+++ b/pkgs/searchpattern.py
@@ -12,6 +12,7 @@ class SearchPattern:
         self.occurance = occurance
         self.blocksize = blocksize
         self._file_contents = {}
+        self._preloaded = False
 
     def _preload_files(self):
         self._file_contents = {}
@@ -38,6 +39,10 @@ class SearchPattern:
         return True
 
     def __checkIfStringInFile(self, file, stringToSearch):
+        if not self._preloaded:
+            self._preload_files()
+            self._preloaded = True
+
         count = 1
 
         for fileCmp, contents in self._file_contents.items():
@@ -48,6 +53,10 @@ class SearchPattern:
         return count
 
     def search(self, file):
+        if not self._preloaded:
+            self._preload_files()
+            self._preloaded = True
+
         # Preprocess the total file size
         sizeCounter = os.stat(file).st_size
 

--- a/yarasilly2.py
+++ b/yarasilly2.py
@@ -35,7 +35,7 @@ def main(rulename=None, filetype=None, matchpatternfile=None, inputfilepath=None
         sys.exit(1)
 
     fileLoader = FileSystemLoader('templates')
-    env = Environment(loader=fileLoader, autoescape=False) # nosec B701
+    env = Environment(loader=fileLoader, autoescape=True)
     yaraTemplate = env.get_template('default.yar')
 
     try:
@@ -128,11 +128,11 @@ def main(rulename=None, filetype=None, matchpatternfile=None, inputfilepath=None
                     if not buf:
                         break
                     if "\x00" in buf:
-                        str = "\"" + buf.split("-",1)[1].replace("\\","\\\\").replace('"','\\"').replace("\x00","") + "\" wide"
-                        strPatterns.append(str)
+                        pattern_string = "\"" + buf.split("-",1)[1].replace("\\","\\\\").replace('"','\\"').replace("\x00","") + "\" wide"
+                        strPatterns.append(pattern_string)
                     else:
-                        str = "\"" + buf.split("-",1)[1].replace("\\","\\\\").replace('"','\\"') + "\""
-                        strPatterns.append(str)
+                        pattern_string = "\"" + buf.split("-",1)[1].replace("\\","\\\\").replace('"','\\"') + "\""
+                        strPatterns.append(pattern_string)
 
             templateValDict["patterns"] = strPatterns
             templateValDict["condition"] = "any of them"


### PR DESCRIPTION
🎯 **What:** The Jinja2 `Environment` was instantiated with `autoescape=False`, which exposes the YARA rule generation process to Server-Side Template Injection (SSTI) vulnerabilities.

⚠️ **Risk:** User-supplied inputs such as `rulename`, `tags`, `author`, and `description` are interpolated into the Jinja2 template. If autoescaping is disabled, an attacker could supply malicious payloads through these inputs. Depending on the environment running the generation script, this could result in arbitrary code execution, sensitive data disclosure, or modification of the underlying system when the template engine processes the unsanitized input.

🛡️ **Solution:** The Jinja2 `Environment` initialization in `yarasilly2.py` was updated to `autoescape=True` to automatically escape potentially dangerous characters during template rendering. The bandit `# nosec B701` suppression comment was removed since the vulnerability has been fixed. Additionally, a small variable shadowing bug in the same file was resolved, and missing state initialization in `pkgs/searchpattern.py` was corrected to fix related failing tests.

---
*PR created automatically by Jules for task [1786137727790262810](https://jules.google.com/task/1786137727790262810) started by @himadriganguly*