### PR TITLE
🧹 [Code Health] Remove unused ppdeep import in run_bench.py

### DIFF
--- a/run_bench.py
+++ b/run_bench.py
@@ -1,7 +1,6 @@
 import time
 import os
 import shutil
-import ppdeep
 from pkgs.fuzzymatch import FuzzyMatch
 
 def run_bench():


### PR DESCRIPTION
🎯 **What:** Removed the unused `import ppdeep` statement from `run_bench.py`.
💡 **Why:** Removing unused imports cleans up the codebase, prevents namespace pollution, and improves overall code readability and maintainability.
✅ **Verification:** Ran `python run_bench.py` and the full test suite (`python -m pytest tests`) to ensure no functionality was affected by this change. The test suite failures are pre-existing issues unrelated to this import removal.
✨ **Result:** The `run_bench.py` script is cleaner and has no unused dependencies.

---
*PR created automatically by Jules for task [6725806129547356882](https://jules.google.com/task/6725806129547356882) started by @himadriganguly*