### PR TITLE
🔒 [Fix] Enable Jinja2 autoescape to prevent SSTI

### DIFF
--- a/yarasilly2.py
+++ b/yarasilly2.py
@@ -3,6 +3,7 @@ from pyfiglet import Figlet
 from clint.textui import puts, colored
 from datetime import datetime
 from jinja2 import Environment, FileSystemLoader
+from markupsafe import Markup
 
 from pkgs.utils import md5sum, listdir
 from pkgs.utils import splitDirFileName
@@ -35,7 +36,7 @@ def main(rulename=None, filetype=None, matchpatternfile=None, inputfilepath=None
         sys.exit(1)
 
     fileLoader = FileSystemLoader('templates')
-    env = Environment(loader=fileLoader, autoescape=False) # nosec B701
+    env = Environment(loader=fileLoader, autoescape=True)
     yaraTemplate = env.get_template('default.yar')
 
     try:
@@ -104,19 +105,13 @@ def main(rulename=None, filetype=None, matchpatternfile=None, inputfilepath=None
 
         shutil.rmtree(tempFolder)
 
-        # Sanitize user inputs to prevent template injection
-        def sanitize(s):
-            if not s:
-                return s
-            return str(s).replace('\\', '\\\\').replace('"', '\\"').replace('\n', ' ').replace('\r', ' ')
-
         if(foundPattern):
             templateValDict = {
                 "ruleName": rulename, # Rule name already regex-checked
-                "ruleTag": sanitize(tags),
-                "authorName": sanitize(author),
+                "ruleTag": tags,
+                "authorName": author,
                 "date": datetime.now().strftime("%Y-%m-%d"),
-                "desc": sanitize(description),
+                "desc": description,
                 "hashArray": fileHash,
                 "fileType": "office"
             }
@@ -129,13 +124,13 @@ def main(rulename=None, filetype=None, matchpatternfile=None, inputfilepath=None
                         break
                     if "\x00" in buf:
                         str_val = "\"" + buf.split("-",1)[1].replace("\\","\\\\").replace('"','\\"').replace("\x00","") + "\" wide"
-                        strPatterns.append(str_val)
+                        strPatterns.append(Markup(str_val))
                     else:
                         str_val = "\"" + buf.split("-",1)[1].replace("\\","\\\\").replace('"','\\"') + "\""
-                        strPatterns.append(str_val)
+                        strPatterns.append(Markup(str_val))
 
             templateValDict["patterns"] = strPatterns
-            templateValDict["condition"] = "any of them"
+            templateValDict["condition"] = Markup("any of them")
 
             yaraOutput = yaraTemplate.render(templateValDict)
 


### PR DESCRIPTION
🎯 **What:** This PR fixes a Server-Side Template Injection (SSTI) vulnerability in the Jinja2 template rendering process. It enables `autoescape=True` on the Jinja2 `Environment` and wraps raw YARA strings in `markupsafe.Markup()`. It also removes the custom `sanitize` function which was an insecure attempt at mitigating this issue.

⚠️ **Risk:** The previous `autoescape=False` configuration (flagged by Bandit B701) could allow malicious payloads within user inputs (like rule tags, author names, or descriptions) to be executed or improperly rendered, potentially breaking the generated YARA rules or causing an SSTI vulnerability if the template engine execution environment is compromised.

🛡️ **Solution:**
- Enabled `autoescape=True` in `Environment`.
- Imported `Markup` from `markupsafe`.
- Wrapped generated `strPatterns` and `condition` in `Markup` to prevent proper YARA syntax (like double quotes) from being HTML-escaped by Jinja2, ensuring the output YARA rules remain valid.
- Removed the custom `sanitize` function entirely and used raw variables directly for `ruleTag`, `authorName`, and `desc` since Jinja2 will automatically and safely escape them now.

---
*PR created automatically by Jules for task [10573937626181083646](https://jules.google.com/task/10573937626181083646) started by @himadriganguly*